### PR TITLE
Correct prebuild DPI order

### DIFF
--- a/full_tf201.mk
+++ b/full_tf201.mk
@@ -27,7 +27,7 @@ PRODUCT_AAPT_CONFIG := xlarge
 PRODUCT_AAPT_PREF_CONFIG := hdpi
 # A list of dpis to select prebuilt apk, in precedence order.
 # See android CCD for valid options
-PRODUCT_AAPT_PREBUILT_DPI := mdpi ldpi tvdpi hdpi xhdpi
+PRODUCT_AAPT_PREBUILT_DPI := mdpi xhdpi hdpi tvdpi ldpi   
 
 # Discard inherited values and use our own instead.
 PRODUCT_NAME := full_tf201

--- a/full_tf300t.mk
+++ b/full_tf300t.mk
@@ -27,7 +27,7 @@ PRODUCT_AAPT_CONFIG := xlarge
 PRODUCT_AAPT_PREF_CONFIG := hdpi
 # A list of dpis to select prebuilt apk, in precedence order.
 # See android CCD for valid options
-PRODUCT_AAPT_PREBUILT_DPI := mdpi ldpi tvdpi hdpi xhdpi
+PRODUCT_AAPT_PREBUILT_DPI := mdpi xhdpi hdpi tvdpi ldpi
 
 # Discard inherited values and use our own instead.
 PRODUCT_NAME := full_tf300t


### PR DESCRIPTION
As it turns out they want us to go from high to low resolution instead of the other way around.
