### PR TITLE
Correct some device values

### DIFF
--- a/full_tf201.mk
+++ b/full_tf201.mk
@@ -31,8 +31,9 @@ PRODUCT_AAPT_PREBUILT_DPI := mdpi ldpi tvdpi hdpi xhdpi
 
 # Discard inherited values and use our own instead.
 PRODUCT_NAME := full_tf201
-PRODUCT_DEVICE := tf201
-PRODUCT_BRAND := Asus
+PRODUCT_DEVICE := TF201
+PRODUCT_BRAND := asus
+PRODUCT_MANUFACTURER := asus
 PRODUCT_MODEL := TF201
 
 # Prime spacific overrides

--- a/full_tf300t.mk
+++ b/full_tf300t.mk
@@ -31,8 +31,9 @@ PRODUCT_AAPT_PREBUILT_DPI := mdpi ldpi tvdpi hdpi xhdpi
 
 # Discard inherited values and use our own instead.
 PRODUCT_NAME := full_tf300t
-PRODUCT_DEVICE := tf300t
-PRODUCT_BRAND := Asus
+PRODUCT_DEVICE := TF300T
+PRODUCT_BRAND := asus
+PRODUCT_MANUFACTURER := asus
 PRODUCT_MODEL := TF300T
 
 # Prime spacific overrides

--- a/full_tf700t.mk
+++ b/full_tf700t.mk
@@ -31,8 +31,9 @@ PRODUCT_AAPT_PREBUILT_DPI := hdpi xhdpi
 
 # Discard inherited values and use our own instead.
 PRODUCT_NAME := full_tf700t
-PRODUCT_DEVICE := tf700t
-PRODUCT_BRAND := Asus
+PRODUCT_DEVICE := TF700T
+PRODUCT_BRAND := asus
+PRODUCT_MANUFACTURER := asus
 PRODUCT_MODEL := TF700T
 
 # Prime spacific overrides


### PR DESCRIPTION
-Set Asus to lower case asus matching the original build.prop
-Add PRODUCT_MANUFACTURER
-Use uppercase for device name

Together these changes will make sure the device is properly reported in the play store.
More additions may be needed to make all asus apps available directly from the play store
