### PR TITLE
Fix cppcheck warnings and errors

### DIFF
--- a/blobpack/blobpack.cpp
+++ b/blobpack/blobpack.cpp
@@ -5,8 +5,8 @@
 #include "blob.h"
 typedef struct
 {
-  char *part_name;
-  char *filename;
+    char *part_name;
+    char *filename;
 } partition_item;
 
 // Number of required arguments before partition definition, including argv[0]
@@ -15,103 +15,102 @@ typedef struct
 int
 main (int argc, char **argv)
 {
-  header_type hdr;
-  char *outname;
-  int i, partnums;
-  partition_item *partitions,*curr_part;
-  secure_header_type shdr;
-  FILE *outfile;
-  part_type *parts;
+    header_type hdr;
+    char *outname;
+    int i, partnums;
+    partition_item *partitions,*curr_part;
+    secure_header_type shdr;
+    FILE *outfile;
+    part_type *parts;
 
-  memset (&hdr, 0, sizeof (header_type));
+    memset (&hdr, 0, sizeof (header_type));
 
-  if (argc < (GENERIC_ARGS+2)) // Require at least one partition
+    if (argc < (GENERIC_ARGS+2)) // Require at least one partition
     {
-      fprintf (stderr,"Usage: %s <outfile> <partitionname> <partitionfile> ...\n", argv[0]);
-      fprintf(stderr, "Any number of partitionname partitionfilename entries can be entered\n");
-      return -1;
+        fprintf (stderr,"Usage: %s <outfile> <partitionname> <partitionfile> ...\n", argv[0]);
+        fprintf(stderr, "Any number of partitionname partitionfilename entries can be entered\n");
+        return -1;
     }
 
-  outname = argv[1];
-  partnums = argc - GENERIC_ARGS; 
+    outname = argv[1];
+    partnums = argc - GENERIC_ARGS;
 
-  if(partnums <= 0 || partnums % 2 != 0)
-  {
-    fprintf(stderr, "Error in parameters. There needs to be equal partition names and partition filenames.");
-    return -1;
-  }
-  // Two parameters per partition. 
-  // At this point we know there is a dividable-by-two number of parameters left
-  partnums = partnums / 2;
-  printf("Found %d partitions as commandline arguments\n", partnums);
-  partitions = (partition_item*)calloc(partnums, sizeof(partition_item));
-  curr_part = partitions;
-  for(i=GENERIC_ARGS; i<argc; i+=2)
-  {
-    printf("Partname: %s Filename: %s\n", argv[i], argv[i+1]);
-    curr_part->part_name = argv[i];
-    curr_part->filename = argv[i+1];
-    curr_part++;
-  };
-
-
-  memcpy(shdr.magic, SEC_MAGIC, SEC_MAGIC_SIZE);
-  
-  memcpy(hdr.magic, MAGIC, MAGIC_SIZE);
-  hdr.version = 0x00010000; // Taken from 
-  hdr.size = hdr.part_offset = sizeof(header_type);
-  hdr.num_parts = partnums;
-
-
-
-  outfile = fopen (outname, "wb");
-  fwrite (&shdr, sizeof (secure_header_type), 1, outfile);
-  fseek ( outfile , 28 , SEEK_SET );
-  fwrite (&hdr, sizeof (header_type), 1, outfile);
-  printf ("Size: %u\n", hdr.size);
-  printf ("%u partitions starting at offset 0x%X\n", hdr.num_parts,
-	  hdr.part_offset);
-
-  parts = (part_type *)calloc (hdr.num_parts, sizeof (part_type));
-  memset(parts, 0, sizeof(part_type)*hdr.num_parts);
-  int currentOffset = sizeof(header_type)+sizeof(part_type)*hdr.num_parts;
-  printf("Offset: %d\n", currentOffset);
-  for (i = 0; i < (int)hdr.num_parts; i++)
-  {
-      FILE *curfile = fopen (partitions[i].filename, "rb");
-      long fsize;
-      memcpy(parts[i].name, partitions[i].part_name, PART_NAME_LEN);
-      parts[i].version = 1; // Version. OK to stay at 1 always.
-      parts[i].offset = currentOffset;
-      
-      if(curfile == NULL)
-      {
-        fprintf(stderr,"Error opening file %s\n", partitions[i].filename);
-		fclose (outfile)
-		free(parts)
-        return 0;
-      }
-      fseek (curfile, 0, SEEK_END);
-      fsize = ftell (curfile);
-      fclose (curfile);
-      parts[i].size = fsize;
-      currentOffset += fsize;
+    if(partnums <= 0 || partnums % 2 != 0)
+    {
+        fprintf(stderr, "Error in parameters. There needs to be equal partition names and partition filenames.");
+        return -1;
     }
-	
-  fwrite (parts, sizeof (part_type), hdr.num_parts, outfile);
-  for (i = 0; i < (int)hdr.num_parts; i++)
-  {
-    // TODO: Don't read in full file in one go. Memory usage!!!
-    char *buffer = (char *) malloc (parts[i].size);
-    FILE *currFile = fopen (partitions[i].filename, "rb");	// Read in update file
-    fread (buffer, 1, parts[i].size, currFile);
-    fclose(currFile);
-    fwrite (buffer, 1, parts[i].size, outfile);
-	free(buffer);
-  };
-  
-  free(parts)
-  fclose (outfile);
-  return 0;
+    // Two parameters per partition.
+    // At this point we know there is a dividable-by-two number of parameters left
+    partnums = partnums / 2;
+    printf("Found %d partitions as commandline arguments\n", partnums);
+    partitions = (partition_item*)calloc(partnums, sizeof(partition_item));
+    curr_part = partitions;
+    for(i=GENERIC_ARGS; i<argc; i+=2)
+    {
+        printf("Partname: %s Filename: %s\n", argv[i], argv[i+1]);
+        curr_part->part_name = argv[i];
+        curr_part->filename = argv[i+1];
+        curr_part++;
+    };
+
+
+    memcpy(shdr.magic, SEC_MAGIC, SEC_MAGIC_SIZE);
+
+    memcpy(hdr.magic, MAGIC, MAGIC_SIZE);
+    hdr.version = 0x00010000; // Taken from
+    hdr.size = hdr.part_offset = sizeof(header_type);
+    hdr.num_parts = partnums;
+
+
+
+    outfile = fopen (outname, "wb");
+    fwrite (&shdr, sizeof (secure_header_type), 1, outfile);
+    fseek ( outfile , 28 , SEEK_SET );
+    fwrite (&hdr, sizeof (header_type), 1, outfile);
+    printf ("Size: %u\n", hdr.size);
+    printf ("%u partitions starting at offset 0x%X\n", hdr.num_parts,
+            hdr.part_offset);
+
+    parts = (part_type *)calloc (hdr.num_parts, sizeof (part_type));
+    memset(parts, 0, sizeof(part_type)*hdr.num_parts);
+    int currentOffset = sizeof(header_type)+sizeof(part_type)*hdr.num_parts;
+    printf("Offset: %d\n", currentOffset);
+    for (i = 0; i < (int)hdr.num_parts; i++)
+    {
+        FILE *curfile = fopen (partitions[i].filename, "rb");
+        long fsize;
+        memcpy(parts[i].name, partitions[i].part_name, PART_NAME_LEN);
+        parts[i].version = 1; // Version. OK to stay at 1 always.
+        parts[i].offset = currentOffset;
+
+        if(curfile == NULL)
+        {
+            fprintf(stderr,"Error opening file %s\n", partitions[i].filename);
+            fclose (outfile)
+            free(parts)
+            return 0;
+        }
+        fseek (curfile, 0, SEEK_END);
+        fsize = ftell (curfile);
+        fclose (curfile);
+        parts[i].size = fsize;
+        currentOffset += fsize;
+    }
+
+    fwrite (parts, sizeof (part_type), hdr.num_parts, outfile);
+    for (i = 0; i < (int)hdr.num_parts; i++)
+    {
+        // TODO: Don't read in full file in one go. Memory usage!!!
+        char *buffer = (char *) malloc (parts[i].size);
+        FILE *currFile = fopen (partitions[i].filename, "rb");	// Read in update file
+        fread (buffer, 1, parts[i].size, currFile);
+        fclose(currFile);
+        fwrite (buffer, 1, parts[i].size, outfile);
+        free(buffer);
+    };
+
+    free(parts)
+    fclose (outfile);
+    return 0;
 }
-

--- a/blobpack/blobpack.cpp
+++ b/blobpack/blobpack.cpp
@@ -68,8 +68,8 @@ main (int argc, char **argv)
   fwrite (&shdr, sizeof (secure_header_type), 1, outfile);
   fseek ( outfile , 28 , SEEK_SET );
   fwrite (&hdr, sizeof (header_type), 1, outfile);
-  printf ("Size: %d\n", hdr.size);
-  printf ("%d partitions starting at offset 0x%X\n", hdr.num_parts,
+  printf ("Size: %u\n", hdr.size);
+  printf ("%u partitions starting at offset 0x%X\n", hdr.num_parts,
 	  hdr.part_offset);
 
   parts = (part_type *)calloc (hdr.num_parts, sizeof (part_type));
@@ -87,6 +87,8 @@ main (int argc, char **argv)
       if(curfile == NULL)
       {
         fprintf(stderr,"Error opening file %s\n", partitions[i].filename);
+		fclose (outfile)
+		free(parts)
         return 0;
       }
       fseek (curfile, 0, SEEK_END);
@@ -95,7 +97,7 @@ main (int argc, char **argv)
       parts[i].size = fsize;
       currentOffset += fsize;
     }
-
+	
   fwrite (parts, sizeof (part_type), hdr.num_parts, outfile);
   for (i = 0; i < (int)hdr.num_parts; i++)
   {
@@ -105,8 +107,10 @@ main (int argc, char **argv)
     fread (buffer, 1, parts[i].size, currFile);
     fclose(currFile);
     fwrite (buffer, 1, parts[i].size, outfile);
+	free(buffer);
   };
-
+  
+  free(parts)
   fclose (outfile);
   return 0;
 }

--- a/blobpack/blobpack.cpp
+++ b/blobpack/blobpack.cpp
@@ -1,33 +1,29 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include "blob.h"
-typedef struct
-{
-    char *part_name;
-    char *filename;
+
+typedef struct {
+    char* part_name;
+    char* filename;
 } partition_item;
 
 // Number of required arguments before partition definition, including argv[0]
 #define GENERIC_ARGS 2
-
 int
-main (int argc, char **argv)
+main(int argc, char** argv)
 {
     header_type hdr;
-    char *outname;
+    char* outname;
     int i, partnums;
-    partition_item *partitions,*curr_part;
+    partition_item* partitions, *curr_part;
     secure_header_type shdr;
-    FILE *outfile;
-    part_type *parts;
+    FILE* outfile;
+    part_type* parts;
+    memset(&hdr, 0, sizeof(header_type));
 
-    memset (&hdr, 0, sizeof (header_type));
-
-    if (argc < (GENERIC_ARGS+2)) // Require at least one partition
-    {
-        fprintf (stderr,"Usage: %s <outfile> <partitionname> <partitionfile> ...\n", argv[0]);
+    if (argc < (GENERIC_ARGS + 2)) { // Require at least one partition
+        fprintf(stderr, "Usage: %s <outfile> <partitionname> <partitionfile> ...\n", argv[0]);
         fprintf(stderr, "Any number of partitionname partitionfilename entries can be entered\n");
         return -1;
     }
@@ -35,82 +31,91 @@ main (int argc, char **argv)
     outname = argv[1];
     partnums = argc - GENERIC_ARGS;
 
-    if(partnums <= 0 || partnums % 2 != 0)
-    {
+    if (partnums <= 0 || partnums % 2 != 0) {
         fprintf(stderr, "Error in parameters. There needs to be equal partition names and partition filenames.");
         return -1;
     }
+
     // Two parameters per partition.
     // At this point we know there is a dividable-by-two number of parameters left
     partnums = partnums / 2;
     printf("Found %d partitions as commandline arguments\n", partnums);
     partitions = (partition_item*)calloc(partnums, sizeof(partition_item));
     curr_part = partitions;
-    for(i=GENERIC_ARGS; i<argc; i+=2)
-    {
-        printf("Partname: %s Filename: %s\n", argv[i], argv[i+1]);
+
+    for (i = GENERIC_ARGS; i < argc; i += 2) {
+        printf("Partname: %s Filename: %s\n", argv[i], argv[i + 1]);
         curr_part->part_name = argv[i];
-        curr_part->filename = argv[i+1];
+        curr_part->filename = argv[i + 1];
         curr_part++;
     };
-
 
     memcpy(shdr.magic, SEC_MAGIC, SEC_MAGIC_SIZE);
 
     memcpy(hdr.magic, MAGIC, MAGIC_SIZE);
+
     hdr.version = 0x00010000; // Taken from
+
     hdr.size = hdr.part_offset = sizeof(header_type);
+
     hdr.num_parts = partnums;
 
+    outfile = fopen(outname, "wb");
 
+    fwrite(&shdr, sizeof(secure_header_type), 1, outfile);
 
-    outfile = fopen (outname, "wb");
-    fwrite (&shdr, sizeof (secure_header_type), 1, outfile);
-    fseek ( outfile , 28 , SEEK_SET );
-    fwrite (&hdr, sizeof (header_type), 1, outfile);
-    printf ("Size: %u\n", hdr.size);
-    printf ("%u partitions starting at offset 0x%X\n", hdr.num_parts,
-            hdr.part_offset);
+    fseek(outfile , 28 , SEEK_SET);
 
-    parts = (part_type *)calloc (hdr.num_parts, sizeof (part_type));
+    fwrite(&hdr, sizeof(header_type), 1, outfile);
+
+    printf("Size: %u\n", hdr.size);
+
+    printf("%u partitions starting at offset 0x%X\n", hdr.num_parts,
+           hdr.part_offset);
+
+    parts = (part_type*)calloc(hdr.num_parts, sizeof(part_type));
+
     memset(parts, 0, sizeof(part_type)*hdr.num_parts);
-    int currentOffset = sizeof(header_type)+sizeof(part_type)*hdr.num_parts;
+
+    int currentOffset = sizeof(header_type) + sizeof(part_type) * hdr.num_parts;
+
     printf("Offset: %d\n", currentOffset);
-    for (i = 0; i < (int)hdr.num_parts; i++)
-    {
-        FILE *curfile = fopen (partitions[i].filename, "rb");
+
+    for (i = 0; i < (int)hdr.num_parts; i++) {
+        FILE* curfile = fopen(partitions[i].filename, "rb");
         long fsize;
         memcpy(parts[i].name, partitions[i].part_name, PART_NAME_LEN);
         parts[i].version = 1; // Version. OK to stay at 1 always.
         parts[i].offset = currentOffset;
 
-        if(curfile == NULL)
-        {
-            fprintf(stderr,"Error opening file %s\n", partitions[i].filename);
-            fclose (outfile)
+        if (curfile == NULL) {
+            fprintf(stderr, "Error opening file %s\n", partitions[i].filename);
+            fclose(outfile)
             free(parts)
             return 0;
         }
-        fseek (curfile, 0, SEEK_END);
-        fsize = ftell (curfile);
-        fclose (curfile);
+
+        fseek(curfile, 0, SEEK_END);
+        fsize = ftell(curfile);
+        fclose(curfile);
         parts[i].size = fsize;
         currentOffset += fsize;
     }
 
-    fwrite (parts, sizeof (part_type), hdr.num_parts, outfile);
-    for (i = 0; i < (int)hdr.num_parts; i++)
-    {
+    fwrite(parts, sizeof(part_type), hdr.num_parts, outfile);
+
+    for (i = 0; i < (int)hdr.num_parts; i++) {
         // TODO: Don't read in full file in one go. Memory usage!!!
-        char *buffer = (char *) malloc (parts[i].size);
-        FILE *currFile = fopen (partitions[i].filename, "rb");	// Read in update file
-        fread (buffer, 1, parts[i].size, currFile);
+        char* buffer = (char*) malloc(parts[i].size);
+        FILE* currFile = fopen(partitions[i].filename, "rb");   // Read in update file
+        fread(buffer, 1, parts[i].size, currFile);
         fclose(currFile);
-        fwrite (buffer, 1, parts[i].size, outfile);
+        fwrite(buffer, 1, parts[i].size, outfile);
         free(buffer);
     };
 
     free(parts)
-    fclose (outfile);
+    fclose(outfile);
+
     return 0;
 }


### PR DESCRIPTION
Fixes the following:
[blobpack.cpp:71]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[blobpack.cpp:72]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[blobpack.cpp:90]: (error) Resource leak: outfile
[blobpack.cpp:111]: (error) Memory leak: parts
[blobpack.cpp:108]: (error) Memory leak: buffer
