### PR TITLE
Remove extended footprint flag

### DIFF
--- a/BoardConfig_common.mk
+++ b/BoardConfig_common.mk
@@ -1,6 +1,5 @@
 # common config for TF201 TF300T TF700T
 
-EXTENDED_FONT_FOOTPRINT := true
 BOARD_USES_GENERIC_AUDIO := false
 # pre kitkat audio legacy policy fix for hotword (ok google) see http://review.cyanogenmod.org/#/c/126869/
 BOARD_HAVE_PRE_KITKAT_AUDIO_BLOB := true


### PR DESCRIPTION
Was removed in this commit
https://github.com/timduru/platform-frameworks-base/commit/5225620508a5a0d39de4f508cec5cecec60f527d
